### PR TITLE
Add prizesk.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1385,6 +1385,7 @@ primfootball.com
 print-technology.ru
 private-service.best
 prizrn.site
+prizesk.com 
 prlog.ru
 probenzo.com.ua
 procrafts.ru


### PR DESCRIPTION
I have daily occurances of `umiq.prizesk.com` on my site. Other users, like in #1237 appear to see different sub-domains, so it probably makes sense to block `prizesk.com` completely.

Redirects to the already blocked `www.xtraffic.plus`.