### PR TITLE
Added own-ahrefs.com (same spammer as semalt.com)

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1288,6 +1288,7 @@ osteochondrosis.ru
 otdbiaxaem-vmeste.ru
 otdyx-s-komfortom.ru
 oudallas.net
+own-ahrefs.com
 ownshop.cf
 ozas.net
 pacobarrero.com


### PR DESCRIPTION
Add own-ahrefs.com based on observations in my logs and https://www.abuseipdb.com/check/62.112.9.54 showing them as part of the semalt.com referral spammer.