### PR TITLE
Add ahhjf.com, which redirects to xtraffic.plus.

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -101,6 +101,7 @@ affordablewebsitesandmobileapps.com
 afora.ru
 agro-gid.com
 agtl.com.ua
+ahhjf.com
 ai-seo-services.com
 aibolita.com
 aidarmebel.kz


### PR DESCRIPTION
Saw a subdomain of it in my Matomo today, everything redirects to xtraffic.