### PR TITLE
exclude fineblog.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -677,6 +677,7 @@ financial-simulation.com
 finansov.info
 finder.cool
 findercarphotos.com
+fineblog.top
 firstblog.top
 fit-discount.ru
 fitodar.com.ua


### PR DESCRIPTION
Found subdomain spam on our site.

```
buctrk.fineblog.top 	1
rjvy.fineblog.top
```