### PR TITLE
Add sloopyjoes.com.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1616,6 +1616,7 @@ sledstvie-veli.net
 slftsdybbg.ru
 slkrm.ru
 slomm.ru
+sloopyjoes.com.top
 slotron.com
 slow-website.xyz
 smailik.org


### PR DESCRIPTION
Redirect to the blacklisted xtrafficplus.com