### PR TITLE
trafficbot4free.xyz

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1812,6 +1812,7 @@ traffic2cash.org
 traffic2cash.xyz
 traffic2money.com
 trafficbot.life
+trafficbot4free.xyz
 trafficgenius.xyz
 trafficmonetize.org
 trafficmonetizer.org


### PR DESCRIPTION
The most common referrer to my academic website in 2020. Is not active anymore, but would be nice to have it filtered from my reports.


