### PR TITLE
Add covblog.top

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -468,6 +468,7 @@ copyrightinstitute.org
 coral-info.com
 cosmediqueresults.com
 covadhosting.biz
+covblog.top
 coverage-my.com
 covid-schutzmasken.de
 cp24.com.ua


### PR DESCRIPTION
Redirect to the blacklisted xtrafficplus.com