### PR TITLE
Add advertisefree.co.uk

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -92,6 +92,7 @@ adspart.com
 adtiger.tk
 adult-video-chat.ru
 adventureparkcostarica.com
+advertisefree.co.uk
 adviceforum.info
 advokateg.xyz
 aerodizain.com


### PR DESCRIPTION
Since a few days, I see around 90 visitors a day from "advertisefree.co.uk". This is clearly fake traffic. Their website sells traffic to your website or something like that.


