### PR TITLE
add marihome.online

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1209,6 +1209,7 @@ maofengjx.com
 marathonbet-in.ru
 marblestyle.ru
 maridan.com.ua
+marihome.online
 marinetraffic.com
 marjorieblog.online
 marketland.ml


### PR DESCRIPTION
redirects to https://www.xtraffic.plus/en/

This one showed up today with multiple apparently randomized subdomains.