### PR TITLE
Add uniqgen.net

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -2013,6 +2013,7 @@ ukstmalls.xyz
 ul-potolki.ru
 undergroundcityphoto.com
 unibus.su
+uniqgen.net
 univerfiles.com
 unlimitdocs.net
 unpredictable.ga


### PR DESCRIPTION
https://uniqgen.net/V2VvGm Gets redirected to random websites, this was added in one of the referral header attacks.