### PR TITLE
Add smzt.shop

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1786,6 +1786,7 @@ slow-website.xyz
 smailik.org
 smartphonediscount.info
 smt4.ru
+smzt.shop
 snabs.kz
 snaiper-bg.net
 sneakerfreaker.com


### PR DESCRIPTION
Subdomains epbgw and lohmx redirects to the blacklisted xtrafficplus.com