### PR TITLE
Add topgurudeals.com

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1967,6 +1967,7 @@ top-l2.com
 top1-seo-service.com
 top10-online-games.com
 top10-way.com
+topgurudeals.com
 topmebeltorg.ru
 toposvita.com
 topquality.cf


### PR DESCRIPTION
Found in my web tracking regularly but that site does not link to my website (ingo-steinke.de / ingo-steinke.com), not even in generic search results.


