### PR TITLE
Block rapidhits.net

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -866,7 +866,7 @@ googlemare.com
 googlsucks.com
 gorgaz.info
 goyua.xyz
-graceonline.shop 
+graceonline.shop
 grafaman.ru
 greatblog.top
 greentechsy.com
@@ -1225,7 +1225,7 @@ lumb.co
 luton-invest.ru
 luxup.ru
 luxurybet.ru
-madisonclothingny.com 
+madisonclothingny.com
 madjonline.xyz
 magicart.store
 magicdiet.gq
@@ -1617,6 +1617,7 @@ ranksonic.info
 ranksonic.net
 ranksonic.org
 rapidgator-porn.ga
+rapidhits.net
 rapidsites.pro
 raschtextil.com.ua
 raymondblog.top


### PR DESCRIPTION
Adding rapidhits.net to the list.

Looks like my editor removed some extra whitespace, lmk if thats a problem and I can manually undo.