### PR TITLE
Add `woduc.com`

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -2215,6 +2215,7 @@ weightbelts.ru
 wfdesigngroup.com
 wjxmenye.com
 wmasterlead.com
+woduc.com
 woman-orgasm.ru
 wordpress-crew.net
 wordpresscore.com


### PR DESCRIPTION
`woduc.com` redirects to `xtraffic.plus` which is already on the list.


