### PR TITLE
Add `osdzc.com`

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1489,6 +1489,7 @@ optsol.ru
 oqex.io
 oracle-patches.ru
 orakul.spb.ru
+osdzc.com
 osteochondrosis.ru
 otdbiaxaem-vmeste.ru
 otdyx-s-komfortom.ru


### PR DESCRIPTION
`osdzc.com` redirects to `xtraffic.plus` which is already on the list.


