### PR TITLE
Add slsif.org to the spammers list

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -1850,6 +1850,7 @@ slomm.ru
 sloopyjoes.com.top
 slotron.com
 slow-website.xyz
+slsif.org
 smailik.org
 smartphonediscount.info
 smt4.ru


### PR DESCRIPTION
They send you spam emails, and when you click on the link, it redirects you to unknown pages repeatedly, but the website itself claims to specialize in supporting tech companies and skills training.


