### PR TITLE
Add new spam domain 'ggl.link' to spammers list

### DIFF
--- a/spammers.txt
+++ b/spammers.txt
@@ -894,6 +894,7 @@ gttpsale.xyz
 guardlink.org
 guidetopetersburg.com
 gxcb.net
+ggl.link
 hagirkblog.space
 halat.xyz
 halefa.com


### PR DESCRIPTION
`ggl.link` redirects to `exirm-my.com` which is empty page and sends a lot of spam emails


